### PR TITLE
Speedup settings for CI server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,7 @@ matrix:
     - php: hhvm-nightly
 
 before_script:
-  - composer self-update
-  - composer install --no-interaction --prefer-source --dev
+  - composer install --no-interaction --prefer-source
 
 script:
   - ./vendor/bin/tester -p $TESTER_PHP_BIN tests/


### PR DESCRIPTION
-  update Composer is not necessary in CI server
- --dev is default configuration in Composer